### PR TITLE
UnhandledPromiseRejectionWarning when route does not render a component

### DIFF
--- a/src/state/fetch.js
+++ b/src/state/fetch.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
  */
 export function fetchData(store, props) {
   return Promise.all(props.components
-    .filter(component => _.isFunction(component.fetchData))
+    .filter(component => component && _.isFunction(component.fetchData))
     .map(component => component.fetchData({
       store,
       location: props.location,


### PR DESCRIPTION
When a route is defined without a component the props.component contains undefined value, resulting in an error (fetchData is not a method of undefined)

This bubbles up to node server as an UnhandledPromiseRejectionWarning and stops the server.

Please note the change here is **not** tested, I got an OS dependency error when trying to test using my fork....

example route which would cause the error
`<Route path="product">
  <Route path="settings" component={ProductSettings} />
  <Route path="inventory" component={ProductInventory} />
  <Route path="orders" component={ProductOrders} />
</Route>`